### PR TITLE
version 1.0.3

### DIFF
--- a/OverheadCombo/OverheadCombo.toc
+++ b/OverheadCombo/OverheadCombo.toc
@@ -2,6 +2,6 @@
 ## Title: OverheadCombo
 ## Notes: Adds combopoints to nameplates
 ## Author: Viliger
-## Version: 1.0.2
+## Version: 1.0.3
 
 OverheadCombo.lua


### PR DESCRIPTION
- fix combo points not showing up and clearing properly
- only load addon if playing rogue/druid to save resources
- fix UNIT_MAXPOWER never being used
- add UNIT_POWER_UPDATE handler to fix combopoint update event

btw this also works with tbc